### PR TITLE
Fixed SimpleAuthWebViewController issue

### DIFF
--- a/SimpleAuthInstagram/ios/SimpleAuthWebViewController.m
+++ b/SimpleAuthInstagram/ios/SimpleAuthWebViewController.m
@@ -26,7 +26,9 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    self.webView.frame = self.view.bounds;
+    CGFloat bottomY = CGRectGetMaxY(self.navigationController.navigationBar.frame) + [UIApplication sharedApplication].statusBarFrame.size.height;
+    
+    self.webView.frame = CGRectMake(self.view.bounds.origin.x, bottomY, self.view.bounds.size.width, self.view.bounds.size.height);
     [self.view addSubview:self.webView];
 }
 


### PR DESCRIPTION
Fixed an issue with the SimpleAuthWebViewController that would cause the Instagram login page to render starting at the top of the devices screen but also underneath the NavigationBar of the webview's UINavigationController. On some devices, this made the username field inaccessible.

Before:
![img_1483](https://user-images.githubusercontent.com/13485734/39614007-1eeac96e-4f21-11e8-8c96-3462bdee2b7d.PNG)

After:
![img_1484](https://user-images.githubusercontent.com/13485734/39614010-27c3268a-4f21-11e8-998c-c252b4302d9f.PNG)
